### PR TITLE
Expose Syslog::VERSION

### DIFF
--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -12,6 +12,8 @@
 #include "ruby/util.h"
 #include <syslog.h>
 
+#define SYSLOG_VERSION "0.1.1"
+
 /* Syslog class */
 static VALUE mSyslog;
 /*
@@ -573,6 +575,8 @@ void Init_syslog(void)
 #endif
 
     /* Syslog macros */
+
+    rb_define_const(mSyslog, "VERSION", rb_str_new_cstr(SYSLOG_VERSION));
 
     rb_define_method(mSyslogMacros, "LOG_MASK", mSyslogMacros_LOG_MASK, 1);
     rb_define_method(mSyslogMacros, "LOG_UPTO", mSyslogMacros_LOG_UPTO, 1);

--- a/syslog.gemspec
+++ b/syslog.gemspec
@@ -1,6 +1,17 @@
+
+source_version = ["", "ext/syslog/"].find do |dir|
+  begin
+    break File.open(File.join(__dir__, "#{dir}syslog.c")) {|f|
+      f.gets("\n#define SYSLOG_VERSION ")
+      f.gets[/\s*"(.+)"/, 1]
+    }
+  rescue Errno::ENOENT
+  end
+end
+
 Gem::Specification.new do |spec|
   spec.name          = "syslog"
-  spec.version       = "0.1.1"
+  spec.version       = source_version
   spec.authors       = ["Akinori MUSHA"]
   spec.email         = ["knu@idaemons.org"]
 


### PR DESCRIPTION
There is no way to refer gem version in Ruby now. I hope to expose gem version by `VERSION` constant.