### PR TITLE
Allow install on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         ruby: [ 2.7, 2.6, 2.5, head ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
           - { os: macos-latest, ruby: '2.5' }
         include:

--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 require 'rake/extensiontask'
-Rake::ExtensionTask.new("syslog")
+Rake::ExtensionTask.new("syslog_ext") do |ext|
+  ext.ext_dir = 'ext/syslog'
+end
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -10,5 +10,11 @@ end
 require 'rake/extensiontask'
 Rake::ExtensionTask.new("syslog_ext") do |ext|
   ext.ext_dir = 'ext/syslog'
+
+  # In contrast to "gem install" a "rake compile" is expecting the C-ext file even on Windows.
+  # Work around by creating a dummy so file.
+  task "#{ext.tmp_dir}/#{ext.platform}/stage/lib" do |t|
+    touch "#{ext.tmp_dir}/#{ext.platform}/#{ext.name}/#{RUBY_VERSION}/#{ext.name}.so"
+  end
 end
 task :default => :test

--- a/ext/syslog/extconf.rb
+++ b/ext/syslog/extconf.rb
@@ -4,10 +4,23 @@
 
 require 'mkmf'
 
-have_library("log") # for Android
+def generate_dummy_makefile
+  File.open("Makefile", "w") do |f|
+    f.puts dummy_makefile("syslog_ext").join
+  end
+end
 
-have_header("syslog.h") &&
-  have_func("openlog") &&
-  have_func("setlogmask") &&
-  create_makefile("syslog")
+def windows?
+  RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+end
 
+if windows?
+  generate_dummy_makefile
+else
+  have_library("log") # for Android
+
+  have_header("syslog.h") &&
+    have_func("openlog") &&
+    have_func("setlogmask") &&
+    create_makefile("syslog_ext")
+end

--- a/ext/syslog/syslog.c
+++ b/ext/syslog/syslog.c
@@ -415,7 +415,7 @@ static VALUE mSyslogMacros_included(VALUE mod, VALUE target)
  *
  * The syslog protocol is standardized in RFC 5424.
  */
-void Init_syslog(void)
+void Init_syslog_ext(void)
 {
 #undef rb_intern
     mSyslog = rb_define_module("Syslog");

--- a/lib/syslog.rb
+++ b/lib/syslog.rb
@@ -1,0 +1,10 @@
+begin
+  require 'syslog_ext'
+rescue LoadError
+  raise LoadError.new(<<-EOS)
+    Can't load Syslog!
+
+    Syslog is not supported on your system. For Windows
+    we recommend using the win32-eventlog gem.
+  EOS
+end


### PR DESCRIPTION
Until ruby-3.3 syslog is shipped with ruby. It is compiled when the POSIX API is available. Otherwise it is skipped and a `require 'syslog'` fails at runtime.

But syslog will not be included in ruby-3.4 any longer. So it's necessary to add it as a gem dependency. Unfortunately this dependency can not be resolved on Windows, since the gem can't be installed there.

This patch allows syslog to be installed on Windows. A `require 'syslog'` fails with a proper error message, if it's not rescued. That way the app/gem can declare dependencies platform independent. And it can use an alternative approach on platforms not supporting syslog.

As an alternative it's also an option to allow install of the gem on non-Windows platforms in case the syslog API isn't available. I can change it that way if preferred.
