### PR TITLE
Drop unused "exe" configuration in gemspec

### DIFF
--- a/syslog.gemspec
+++ b/syslog.gemspec
@@ -22,7 +22,5 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.extensions    = ["ext/syslog/extconf.rb"]
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This gem exposes no executables, so we can omit the configuration of that in the gemspec.