### PR TITLE
Enable building on Cygwin.

### DIFF
--- a/ext/syslog/extconf.rb
+++ b/ext/syslog/extconf.rb
@@ -11,7 +11,7 @@ def generate_dummy_makefile
 end
 
 def windows?
-  RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+  RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
 end
 
 if windows?


### PR DESCRIPTION
The syslog ext builds fine there.

Due to [another issue](https://bugs.ruby-lang.org/issues/21092), the dummy makefile causes the build of the ruby 3.4.1 distribution to fail with

```
../ruby-3.4.1/ext/extmk.rb:279:in 'Array#-': no implicit conversion of nil into Array (TypeError)
        from ../ruby-3.4.1/ext/extmk.rb:279:in 'Object#extmake'
        from ../ruby-3.4.1/ext/extmk.rb:659:in 'block in <main>'
        from ../ruby-3.4.1/ext/extmk.rb:653:in 'Array#each'
        from ../ruby-3.4.1/ext/extmk.rb:653:in '<main>'
```

For my lack of ruby knowledge, this was the easier thing to patch to get things building.