### PR TITLE
Add `logger` as a dependency

### DIFF
--- a/syslog.gemspec
+++ b/syslog.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   end
   spec.extensions    = ["ext/syslog/extconf.rb"]
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "logger"
 end


### PR DESCRIPTION
This PR adds the `logger` to explicit dependency to fix the following warning.

```
src/github.com/ruby/syslog/lib/syslog/logger.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```